### PR TITLE
Add lifecycle observer

### DIFF
--- a/app/src/main/java/com/example/android/dessertpusher/DessertTimer.kt
+++ b/app/src/main/java/com/example/android/dessertpusher/DessertTimer.kt
@@ -17,6 +17,8 @@
 package com.example.android.dessertpusher
 
 import android.os.Handler
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
 import timber.log.Timber
 
 /**
@@ -34,7 +36,7 @@ import timber.log.Timber
  * https://developer.android.com/guide/components/processes-and-threads
  *
  */
-class DessertTimer {
+class DessertTimer(lifecycle: Lifecycle) : LifecycleObserver {
 
     // The number of seconds counted since the timer started
     var secondsCount = 0
@@ -46,6 +48,9 @@ class DessertTimer {
     private var handler = Handler()
     private lateinit var runnable: Runnable
 
+    init {
+        lifecycle.addObserver(this)
+    }
 
     fun startTimer() {
         // Create the runnable action, which prints out a log and increments the seconds counter

--- a/app/src/main/java/com/example/android/dessertpusher/DessertTimer.kt
+++ b/app/src/main/java/com/example/android/dessertpusher/DessertTimer.kt
@@ -19,6 +19,7 @@ package com.example.android.dessertpusher
 import android.os.Handler
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
 import timber.log.Timber
 
 /**
@@ -52,6 +53,7 @@ class DessertTimer(lifecycle: Lifecycle) : LifecycleObserver {
         lifecycle.addObserver(this)
     }
 
+    @OnLifecycleEvent(Lifecycle.Event.ON_START)
     fun startTimer() {
         // Create the runnable action, which prints out a log and increments the seconds counter
         runnable = Runnable {
@@ -70,6 +72,7 @@ class DessertTimer(lifecycle: Lifecycle) : LifecycleObserver {
         // In this case, no looper is defined, and it defaults to the main or UI thread.
     }
 
+    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     fun stopTimer() {
         // Removes all pending posts of runnable from the handler's queue, effectively stopping the
         // timer

--- a/app/src/main/java/com/example/android/dessertpusher/MainActivity.kt
+++ b/app/src/main/java/com/example/android/dessertpusher/MainActivity.kt
@@ -18,6 +18,7 @@ package com.example.android.dessertpusher
 
 import android.content.ActivityNotFoundException
 import android.os.Bundle
+import android.os.PersistableBundle
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
@@ -97,6 +98,11 @@ class MainActivity : AppCompatActivity(), LifecycleObserver {
 
         // Show the next dessert
         showCurrentDessert()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        Timber.i("onSaveInstanceState Called")
     }
 
     /**

--- a/app/src/main/java/com/example/android/dessertpusher/MainActivity.kt
+++ b/app/src/main/java/com/example/android/dessertpusher/MainActivity.kt
@@ -100,11 +100,6 @@ class MainActivity : AppCompatActivity(), LifecycleObserver {
         showCurrentDessert()
     }
 
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        Timber.i("onSaveInstanceState Called")
-    }
-
     /**
      * Determine which dessert to show.
      */
@@ -154,6 +149,12 @@ class MainActivity : AppCompatActivity(), LifecycleObserver {
             R.id.shareMenuButton -> onShare()
         }
         return super.onOptionsItemSelected(item)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putInt("key_revenue", revenue)
+        Timber.i("onSaveInstanceState Called")
     }
 
     override fun onStart() {

--- a/app/src/main/java/com/example/android/dessertpusher/MainActivity.kt
+++ b/app/src/main/java/com/example/android/dessertpusher/MainActivity.kt
@@ -77,6 +77,9 @@ class MainActivity : AppCompatActivity(), LifecycleObserver {
         }
         dessertTimer = DessertTimer(this.lifecycle)
         // Set the TextViews to the right values
+
+        if (savedInstanceState != null) revenue = savedInstanceState.getInt("key_revenue", 0)
+
         binding.revenue = revenue
         binding.amountSold = dessertsSold
 

--- a/app/src/main/java/com/example/android/dessertpusher/MainActivity.kt
+++ b/app/src/main/java/com/example/android/dessertpusher/MainActivity.kt
@@ -34,6 +34,7 @@ class MainActivity : AppCompatActivity(), LifecycleObserver {
     private var revenue = 0
     private var dessertsSold = 0
     private lateinit var dessertTimer: DessertTimer
+
     // Contains all the views
     private lateinit var binding: ActivityMainBinding
 
@@ -73,7 +74,7 @@ class MainActivity : AppCompatActivity(), LifecycleObserver {
         binding.dessertButton.setOnClickListener {
             onDessertClicked()
         }
-        dessertTimer = DessertTimer()
+        dessertTimer = DessertTimer(this.lifecycle)
         // Set the TextViews to the right values
         binding.revenue = revenue
         binding.amountSold = dessertsSold


### PR DESCRIPTION
## Description

Add and use Lifecycle Observation to start and stop the timer.
Ensure that data is saved and restored, even if app is shut down in the background.

### [Task]

https://classroom.udacity.com/courses/ud9012/lessons/e487c600-ed68-4576-a35a-12f211cf032e/concepts/425cffb4-077b-439b-b09d-ebc5787675e8

## Steps to Test or Reproduce
1.Start the app
2.Open Logcat
3.Navigate away
4.Terminate the process:
- Make sure you are using a device or emulator running at least API level 28. This is easier to set up for an emulator.
- Make sure adb is installed. If not, see instructions below.
- Make sure your app is in the background - this only happens when the app is in the background. You can do this by hitting the home button.
- Run the command:    adb shell am kill com.example.android.dessertpusher